### PR TITLE
Refactored dicts used in config to cut typing efforts, allow easier c…

### DIFF
--- a/examples/HowToUseTutorial.ipynb
+++ b/examples/HowToUseTutorial.ipynb
@@ -1,0 +1,308 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# How to convert atom probe (meta)data to NeXus/HDF5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The aim of this tutorial is to guide users how to create a NeXus/HDF5 file to parse and normalize pieces of information<br>\n",
+    "from typical file formats of the atom probe community into a common form. The tool assures that this NeXus file matches<br>\n",
+    "to the NXapm application definition. Such documented conceptually, the file can be used for sharing atom probe research<br>\n",
+    "with others (colleagues, project partners, the public), for uploading a summary of the (meta)data to public repositories<br>\n",
+    "and thus avoiding additional work that is typically with having to write documentation of metadata in such repositories<br>\n",
+    "or a research data management systems like NOMAD Oasis.<br>\n",
+    "\n",
+    "The benefit of the data normalization that pynxtools-apm performs is that all pieces of information are represents in the<br>\n",
+    "same conceptual way with the benefit that most of the so far required format conversions when interfacing with software<br>\n",
+    "from the technology partners or scientific community are no longer necessary.<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### **Step 1:** Check that packages are installed and working in your local Python environment."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check the result of the query below specifically that `jupyterlab_h5web` and `pynxtools` are installed in your environment.<br>\n",
+    "Note that next to the name pynxtools you should see the directory in which it is installed. Otherwise, make sure that you follow<br>\n",
+    "the instructions in the `README` files:  \n",
+    "- How to set up a development environment as in the main README  \n",
+    "- Lauch the jupyter lab from this environement as in the README of folder `examples`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "h5py                      3.10.0\n",
+      "jupyter_client            8.6.1\n",
+      "jupyter_core              5.7.2\n",
+      "pynxtools                 0.1.1.post1.dev64+g43f5e6f.d20240331\n",
+      "pynxtools-apm             0.0.post1.dev22+g5645326             /home/mkuehbach/sprint19/apm/pynxtools_apm\n"
+     ]
+    }
+   ],
+   "source": [
+    "! pip list | grep \"h5py\\|nexus\\|jupyter\\|jupyterlab_h5web\\|pynxtools\\|pynxtools-apm\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set the pynxtools directory and start H5Web for interactive exploring of HDF5 files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current working directory: /home/mkuehbach/sprint19/apm/pynxtools_apm/examples\n",
+      "So-called base, home, or root directory of the pynxtools: /home/mkuehbach/sprint19/apm/pynxtools_apm/examples\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import zipfile as zp\n",
+    "import numpy as np\n",
+    "from jupyterlab_h5web import H5Web\n",
+    "print(f\"Current working directory: {os.getcwd()}\")\n",
+    "print(f\"So-called base, home, or root directory of the pynxtools: {os.getcwd().replace('/examples/apm', '')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **Step 2:** Use your own data or download an example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Example data can be found on Zenodo https://www.zenodo.org/record/7986279."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
+      "                                 Dload  Upload   Total   Spent    Left  Speed\n",
+      "100 53.1M  100 53.1M    0     0  1235k      0  0:00:44  0:00:44 --:--:-- 1262k\n"
+     ]
+    }
+   ],
+   "source": [
+    "! curl --output usa_denton_smith_apav_si.zip https://zenodo.org/records/7986279/files/usa_denton_smith_apav_si.zip?download=1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zp.ZipFile(\"usa_denton_smith_apav_si.zip\").extractall(path=\"\", members=None, pwd=None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-danger\">\n",
+    "Please note that the metadata inside the provided apm.oasis.specific.yaml and eln_data_apm.yaml files<br>\n",
+    "contain exemplar values. These do not necessarily reflect the conditions when the raw data of example<br>\n",
+    "above-mentioned were collected by the scientists. Instead, these file are meant to be edited by you,<br>\n",
+    "either and preferably programmatically e.g. using output from an electronic lab notebook or manually.</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This example shows the types of files from which the parser collects and normalizes pieces of information:<br>\n",
+    "* **eln_data_apm.yaml** metadata collected with an electronic lab notebook (ELN) such as a NOMAD Oasis custom schema<br>\n",
+    "* **apm.oasis.specific.yaml** frequently used metadata that are often the same for many datasets to avoid having to<br>\n",
+    "  type it every time in ELN templates. This file can be considered a configuration file whereby e.g. coordinate system<br>\n",
+    "  conventions can be injected or details about the atom probe instrument communicated if that is part of frequently used<br>\n",
+    "  lab equipment. The benefit of such an approach is that eventual all relevant metadata to an instrument can be read from\n",
+    "  this configuration file via guiding the user e.g. through the ELN with an option to select the instrument.<br>\n",
+    "* **reconstructed ion positions** in community, technology partner format with<br>\n",
+    "  the ion positions and mass-to-charge state ratio values for the tomographic reconstruction.<br>\n",
+    "* **ranging definitions** in community / technology partner formatting with<br>\n",
+    "  the definitions how mass-to-charge-state-ratio values map on ion species.<br>\n",
+    "\n",
+    "The tool supports the most commonly used information exchange formats of the atom probe community.<br>\n",
+    "Consult the reference part of the documentation to get a detailed view on how specific formats are supported.<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "Please note that the proprietary file formats RRAW, STR, ROOT, RHIT, and HITS from AMETEK/Cameca are currently not processable<br>\n",
+    "with pynxtools-apm although we have investigated the situation and were able confirm that a substantial number of metadata have been<br>\n",
+    "documented by Cameca and are technically extractable and interpretable using Python. This would enable automated mapping and<br>normalizing of these metadata into NeXus via simpler than the current route where an additional ELN or supplementary file like yaml has to be<br>\n",
+    "used for and eventually users have to enter the same information more than once. AMETEK/Cameca is currently working on<br>\n",
+    "the implementation of features in AP Suite to make some of these metadata available through the open-source APT file format<br>\n",
+    "when this is available we will work on an update of pynxtools-apm to support this functionality.</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### **Step 3:** Run the parser"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "eln_data_file_name = [\"eln_data_apm.yaml\"]\n",
+    "deployment_specific = [\"apm.oasis.specific.yaml\"]\n",
+    "input_recon_file_name = [\"Si.apt\",\n",
+    "                         \"Si.epos\",\n",
+    "                         \"Si.pos\",\n",
+    "input_range_file_name = [\"Si.RRNG\",\n",
+    "                         \"Si.RNG\",\n",
+    "                         \"Si.RNG\",\n",
+    "output_file_name = [\"apm.case1.nxs\",\n",
+    "                    \"apm.case2.nxs\",\n",
+    "                    \"apm.case3.nxs\"]\n",
+    "for case_id in np.arange(0, 3):\n",
+    "    ELN = eln_data_file_name[0]\n",
+    "    CFG = deployment_specific[0]\n",
+    "    RECON = input_recon_file_name[case_id]\n",
+    "    RANGE = input_range_file_name[case_id]\n",
+    "    OUTPUT = output_file_name[case_id]\n",
+    "\n",
+    "    ! dataconverter convert $ELN $CFG $RECON $RANGE --reader apm --nxdl NXapm --output $OUTPUT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### **Step 4:** Inspect the NeXus/HDF5 file using H5Web."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "H5Web(OUTPUT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The NeXus file an also be viewed with H5Web by opening it via the file explorer panel to the left side of this Jupyter lab window."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Conclusions:\n",
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This tutorial showed how you can call the pynxtools-apm via a jupyter notebook.<br>\n",
+    "This opens many possibilities like processing the results further with Python such as through e.g.<br>\n",
+    "<a href=\"https://conda.io/projects/conda/en/latest/user-guide/install/index.html\">conda</a> on your local computer, <a href=\"https://docs.python.org/3/tutorial/venv.html\">a virtual environment</a>, to interface with AMETEK/Cameca\\'s AP Suite<br>\n",
+    "<a href=\"https://github.com/CamecaAPT/cameca-customanalysis-interface/wiki\">extension interface</a> to do processing of the data with scientific software from the atom probe<br>\n",
+    "such as <a href=\"https://github.com/FAIRmat-NFDI/AreaB-software-tools\">open-source tools</a> (paraprobe-toolbox and others</a>) or IVAS / AP Suite.<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Contact person for pynxtools-apm and related examples in FAIRmat:\n",
+    "Dr.-Ing. Markus Kühbach, 2024/04/18<br>\n",
+    "\n",
+    "### Funding\n",
+    "<a href=\"https://www.fairmat-nfdi.eu/fairmat\">FAIRmat</a> is a consortium on research data management which is part of the German NFDI.<br>\n",
+    "The project is funded by the Deutsche Forschungsgemeinschaft (DFG, German Research Foundation) – project 460197019."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pynxtools_apm/config/apm_example_eln_to_nx_map_2.py
+++ b/pynxtools_apm/config/apm_example_eln_to_nx_map_2.py
@@ -20,101 +20,142 @@
 ENTRY_TO_NEXUS = {
     "prefix_trg": "/ENTRY[entry*]",
     "prefix_src": "entry",
-    "map_to_str": [("run_number"), ("operation_mode"), ("method"), ("start_time"), ("end_time"), ("experiment_description")],
+    "map_to_str": [
+        ("experiment_alias", "run_number"),
+        ("run_number"),
+        ("operation_mode"),
+        ("method"),
+        ("start_time"),
+        ("end_time"),
+        ("experiment_description"),
+    ],
 }
 
 
 SAMPLE_TO_NEXUS = {
     "prefix_trg": "/ENTRY[entry*]/sample",
     "prefix_src": "sample",
-    "use": [("method", "experiment")]
-    "map_to_real": [("grain_diameter", "grain_diameter/value"),
-                    ("grain_diameter_error", "grain_diameter_error/value"),
-                    ("heat_treatment_temperature", "heat_treatment_temperature/value"),
-                    ("heat_treatment_temperature_error", "heat_treatment_temperature_error/value"),
-                    ("heat_treatment_quenching_rate", "heat_treatment_quenching_rate/value"),
-                    ("heat_treatment_quenching_rate_error", "heat_treatment_quenching_rate_error/value")],
-    "map_to_str": [("alias"), ("description"),
-                   ("grain_diameter/@units", "grain_diameter/unit"),
-                   ("grain_diameter_error/@units", "grain_diameter/unit"),
-                   ("heat_treatment_temperature/@units", "heat_treatment_temperature/unit"),
-                   ("heat_treatment_temperature_error/@units", "heat_treatment_temperature_error/unit"),
-                   ("heat_treatment_quenching_rate/@units", "heat_treatment_quenching_rate/unit"),
-                   ("heat_treatment_quenching_rate_error/@units", "heat_treatment_quenching_rate_error/unit")],
+    "use": [("method", "experiment")],
+    "map_to_real": [
+        ("grain_diameter", "grain_diameter/value"),
+        ("grain_diameter_error", "grain_diameter_error/value"),
+        ("heat_treatment_temperature", "heat_treatment_temperature/value"),
+        ("heat_treatment_temperature_error", "heat_treatment_temperature_error/value"),
+        ("heat_treatment_quenching_rate", "heat_treatment_quenching_rate/value"),
+        (
+            "heat_treatment_quenching_rate_error",
+            "heat_treatment_quenching_rate_error/value",
+        ),
+    ],
+    "map_to_str": [
+        ("alias"),
+        ("description"),
+        ("grain_diameter/@units", "grain_diameter/unit"),
+        ("grain_diameter_error/@units", "grain_diameter/unit"),
+        ("heat_treatment_temperature/@units", "heat_treatment_temperature/unit"),
+        (
+            "heat_treatment_temperature_error/@units",
+            "heat_treatment_temperature_error/unit",
+        ),
+        ("heat_treatment_quenching_rate/@units", "heat_treatment_quenching_rate/unit"),
+        (
+            "heat_treatment_quenching_rate_error/@units",
+            "heat_treatment_quenching_rate_error/unit",
+        ),
+    ],
 }
 
 
 SPECIMEN_TO_NEXUS = {
     "prefix_trg": "/ENTRY[entry*]/specimen",
     "prefix_src": "specimen",
-    "map_to_str": [("alias"), ("preparation_date"), ("description"),
-                   ("initial_radius/@units", "initial_radius/unit"),
-                   ("shank_angle/@units", "shank_angle/unit")],
-    "map_to_bool": [("is_polycrystalline"), ("is_amorphous")]
-    "map_to_real": [("initial_radius", "initial_radius/value"),
-                    ("shank_angle", "shank_angle/value")],
+    "map_to_str": [
+        ("alias"),
+        ("preparation_date"),
+        ("description"),
+        ("initial_radius/@units", "initial_radius/unit"),
+        ("shank_angle/@units", "shank_angle/unit"),
+    ],
+    "map_to_bool": [("is_polycrystalline"), ("is_amorphous")],
+    "map_to_real": [
+        ("initial_radius", "initial_radius/value"),
+        ("shank_angle", "shank_angle/value"),
+    ],
 }
 
 
 INSTRUMENT_STATIC_TO_NEXUS = {
     "prefix_trg": "/ENTRY[entry*]/measurement/instrument",
     "prefix_src": "atom_probe",
-    "map_to_str": [("status"), ("instrument_name"), ("location"),
-                   ("FABRICATION[fabrication]/vendor", "fabrication_vendor"),
-                   ("FABRICATION[fabrication]/model", "fabrication_model"),
-                   ("FABRICATION[fabrication]/identifier", "fabrication_identifier"),
-                   ("reflectron/status", "reflectron_status"),
-                   ("local_electrode/name", "local_electrode_name"),
-                   ("pulser/pulse_mode", "pulser/pulse_mode"),
-                   ("analysis_chamber/flight_path/@units", "nominal_flight_path/unit")]
-    "map_to_real": ["analysis_chamber/flight_path", "nominal_flight_path/value")]
+    "map_to_str": [
+        ("status"),
+        ("instrument_name"),
+        ("location"),
+        ("FABRICATION[fabrication]/vendor", "fabrication_vendor"),
+        ("FABRICATION[fabrication]/model", "fabrication_model"),
+        ("FABRICATION[fabrication]/identifier", "fabrication_identifier"),
+        ("reflectron/status", "reflectron_status"),
+        ("local_electrode/name", "local_electrode_name"),
+        ("pulser/pulse_mode", "pulser/pulse_mode"),
+        ("analysis_chamber/flight_path/@units", "nominal_flight_path/unit"),
+    ],
+    "map_to_real": [("analysis_chamber/flight_path", "nominal_flight_path/value")],
 }
 
 
 INSTRUMENT_DYNAMIC_TO_NEXUS = {
     "prefix_trg": "/ENTRY[entry*]/measurement/event_data_apm_set/EVENT_DATA_APM[event_data_apm]/instrument",
     "prefix_src": "atom_probe",
-    "use": [("control/target_detection_rate/@units", "ions/pulse"),
-    
-    "map_to_str": [("control/evaporation_control", "evaporation_control"),
-                   ("pulser/pulse_frequency/@units", "pulser/pulse_frequency/unit"),
-                   ("analysis_chamber/chamber_pressure/@units", "chamber_pressure/unit"),
-                   ("stage_lab/base_temperature/@units", "stage_lab/base_temperature/unit")],
-    "map_to_real": [("control/target_detection_rate", "target_detection_rate"),
-                    ("pulser/pulse_frequency", "pulser/pulse_frequency/value"),
-                    ("pulser/pulse_fraction", "pulser/pulse_fraction/value"),
-                    ("analysis_chamber/chamber_pressure", "chamber_pressure/value"),
-                    ("stage_lab/base_temperature", "base_temperature/value")]
+    "use": [("control/target_detection_rate/@units", "ions/pulse")],
+    "map_to_str": [
+        ("control/evaporation_control", "evaporation_control"),
+        ("pulser/pulse_frequency/@units", "pulser/pulse_frequency/unit"),
+        ("analysis_chamber/chamber_pressure/@units", "chamber_pressure/unit"),
+        ("stage_lab/base_temperature/@units", "stage_lab/base_temperature/unit"),
+    ],
+    "map_to_real": [
+        ("control/target_detection_rate", "target_detection_rate"),
+        ("pulser/pulse_frequency", "pulser/pulse_frequency/value"),
+        ("pulser/pulse_fraction", "pulser/pulse_fraction/value"),
+        ("analysis_chamber/chamber_pressure", "chamber_pressure/value"),
+        ("stage_lab/base_temperature", "base_temperature/value"),
+    ],
 }
 
 
 RANGE_TO_NEXUS = {
     "prefix_trg": "/ENTRY[entry*]/atom_probe/ranging",
     "prefix_src": "ranging",
-    "map_to_str": [("programID[program1]/program", "program"),
-                   ("programID[program1]/program/@version", "program_version")]
+    "map_to_str": [
+        ("programID[program1]/program", "program"),
+        ("programID[program1]/program/@version", "program_version"),
+    ],
 }
 
 
 RECON_TO_NEXUS = {
     "prefix_trg": "/ENTRY[entry*]/atom_probe/reconstruction",
     "prefix_src": "reconstruction",
-    "map_to_str": [("programID[program1]/program", "program"),
-                   ("programID[program1]/program/@version", "program_version"),
-                   ("field_of_view/@units", "field_of_view/unit"),
-                   ("protocol_name"),
-                   ("crystallographic_calibration"),
-                   ("parameter")],
-    "map_to_real": [("field_of_view", "field_of_view/value")]
+    "map_to_str": [
+        ("programID[program1]/program", "program"),
+        ("programID[program1]/program/@version", "program_version"),
+        ("field_of_view/@units", "field_of_view/unit"),
+        ("protocol_name"),
+        ("crystallographic_calibration"),
+        ("parameter"),
+    ],
+    "map_to_real": [("field_of_view", "field_of_view/value")],
 }
 
 
 WORKFLOW_TO_NEXUS = {
     "prefix_trg": "/ENTRY[entry*]/atom_probe",
     "prefix_src": "workflow",
-    "sha256": [("raw_data/SERIALIZED[serialized]/checksum", "raw_dat_file"),
-               ("hit_finding/SERIALIZED[serialized]/checksum", "hit_dat_file"),
-               ("reconstruction/config/checksum", "recon_cfg_file")]
+    "sha256": [
+        ("raw_data/SERIALIZED[serialized]/checksum", "raw_dat_file"),
+        ("hit_finding/SERIALIZED[serialized]/checksum", "hit_dat_file"),
+        ("reconstruction/config/checksum", "recon_cfg_file"),
+    ],
 }
 
 # NeXus concept specific mapping tables which require special treatment as the current
@@ -124,10 +165,18 @@ WORKFLOW_TO_NEXUS = {
 APM_EXAMPLE_USER_TO_NEXUS = {
     "prefix_trg": "/ENTRY[entry*]/USER[user*]",
     "use": [("IDENTIFIER[identifier]/is_persistent", False)],
-    "map_to_str": [("name"), ("affiliation"), ("address"), ("email"), ("telephone_number"), ("role"),
-                   ("social_media_name"), ("social_media_platform"),
-                   ("IDENTIFIER[identifier]/identifier", "orcid"),
-                   ("IDENTIFIER[identifier]/service", "orcid")],
+    "map_to_str": [
+        ("name"),
+        ("affiliation"),
+        ("address"),
+        ("email"),
+        ("telephone_number"),
+        ("role"),
+        ("social_media_name"),
+        ("social_media_platform"),
+        ("IDENTIFIER[identifier]/identifier", "orcid"),
+        ("IDENTIFIER[identifier]/service", "orcid"),
+    ],
 }
 
 # LEAP6000 can use up to two lasers and voltage pulsing (both at the same time?)

--- a/pynxtools_apm/config/apm_example_eln_to_nx_map_2.py
+++ b/pynxtools_apm/config/apm_example_eln_to_nx_map_2.py
@@ -1,0 +1,138 @@
+#
+# Copyright The NOMAD Authors.
+#
+# This file is part of NOMAD. See https://nomad-lab.eu for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Dict mapping custom schema instances from eln_data.yaml file on concepts in NXapm."""
+
+ENTRY_TO_NEXUS = {
+    "prefix_trg": "/ENTRY[entry*]",
+    "prefix_src": "entry",
+    "map_to_str": [("run_number"), ("operation_mode"), ("method"), ("start_time"), ("end_time"), ("experiment_description")],
+}
+
+
+SAMPLE_TO_NEXUS = {
+    "prefix_trg": "/ENTRY[entry*]/sample",
+    "prefix_src": "sample",
+    "use": [("method", "experiment")]
+    "map_to_real": [("grain_diameter", "grain_diameter/value"),
+                    ("grain_diameter_error", "grain_diameter_error/value"),
+                    ("heat_treatment_temperature", "heat_treatment_temperature/value"),
+                    ("heat_treatment_temperature_error", "heat_treatment_temperature_error/value"),
+                    ("heat_treatment_quenching_rate", "heat_treatment_quenching_rate/value"),
+                    ("heat_treatment_quenching_rate_error", "heat_treatment_quenching_rate_error/value")],
+    "map_to_str": [("alias"), ("description"),
+                   ("grain_diameter/@units", "grain_diameter/unit"),
+                   ("grain_diameter_error/@units", "grain_diameter/unit"),
+                   ("heat_treatment_temperature/@units", "heat_treatment_temperature/unit"),
+                   ("heat_treatment_temperature_error/@units", "heat_treatment_temperature_error/unit"),
+                   ("heat_treatment_quenching_rate/@units", "heat_treatment_quenching_rate/unit"),
+                   ("heat_treatment_quenching_rate_error/@units", "heat_treatment_quenching_rate_error/unit")],
+}
+
+
+SPECIMEN_TO_NEXUS = {
+    "prefix_trg": "/ENTRY[entry*]/specimen",
+    "prefix_src": "specimen",
+    "map_to_str": [("alias"), ("preparation_date"), ("description"),
+                   ("initial_radius/@units", "initial_radius/unit"),
+                   ("shank_angle/@units", "shank_angle/unit")],
+    "map_to_bool": [("is_polycrystalline"), ("is_amorphous")]
+    "map_to_real": [("initial_radius", "initial_radius/value"),
+                    ("shank_angle", "shank_angle/value")],
+}
+
+
+INSTRUMENT_STATIC_TO_NEXUS = {
+    "prefix_trg": "/ENTRY[entry*]/measurement/instrument",
+    "prefix_src": "atom_probe",
+    "map_to_str": [("status"), ("instrument_name"), ("location"),
+                   ("FABRICATION[fabrication]/vendor", "fabrication_vendor"),
+                   ("FABRICATION[fabrication]/model", "fabrication_model"),
+                   ("FABRICATION[fabrication]/identifier", "fabrication_identifier"),
+                   ("reflectron/status", "reflectron_status"),
+                   ("local_electrode/name", "local_electrode_name"),
+                   ("pulser/pulse_mode", "pulser/pulse_mode"),
+                   ("analysis_chamber/flight_path/@units", "nominal_flight_path/unit")]
+    "map_to_real": ["analysis_chamber/flight_path", "nominal_flight_path/value")]
+}
+
+
+INSTRUMENT_DYNAMIC_TO_NEXUS = {
+    "prefix_trg": "/ENTRY[entry*]/measurement/event_data_apm_set/EVENT_DATA_APM[event_data_apm]/instrument",
+    "prefix_src": "atom_probe",
+    "use": [("control/target_detection_rate/@units", "ions/pulse"),
+    
+    "map_to_str": [("control/evaporation_control", "evaporation_control"),
+                   ("pulser/pulse_frequency/@units", "pulser/pulse_frequency/unit"),
+                   ("analysis_chamber/chamber_pressure/@units", "chamber_pressure/unit"),
+                   ("stage_lab/base_temperature/@units", "stage_lab/base_temperature/unit")],
+    "map_to_real": [("control/target_detection_rate", "target_detection_rate"),
+                    ("pulser/pulse_frequency", "pulser/pulse_frequency/value"),
+                    ("pulser/pulse_fraction", "pulser/pulse_fraction/value"),
+                    ("analysis_chamber/chamber_pressure", "chamber_pressure/value"),
+                    ("stage_lab/base_temperature", "base_temperature/value")]
+}
+
+
+RANGE_TO_NEXUS = {
+    "prefix_trg": "/ENTRY[entry*]/atom_probe/ranging",
+    "prefix_src": "ranging",
+    "map_to_str": [("programID[program1]/program", "program"),
+                   ("programID[program1]/program/@version", "program_version")]
+}
+
+
+RECON_TO_NEXUS = {
+    "prefix_trg": "/ENTRY[entry*]/atom_probe/reconstruction",
+    "prefix_src": "reconstruction",
+    "map_to_str": [("programID[program1]/program", "program"),
+                   ("programID[program1]/program/@version", "program_version"),
+                   ("field_of_view/@units", "field_of_view/unit"),
+                   ("protocol_name"),
+                   ("crystallographic_calibration"),
+                   ("parameter")],
+    "map_to_real": [("field_of_view", "field_of_view/value")]
+}
+
+
+WORKFLOW_TO_NEXUS = {
+    "prefix_trg": "/ENTRY[entry*]/atom_probe",
+    "prefix_src": "workflow",
+    "sha256": [("raw_data/SERIALIZED[serialized]/checksum", "raw_dat_file"),
+               ("hit_finding/SERIALIZED[serialized]/checksum", "hit_dat_file"),
+               ("reconstruction/config/checksum", "recon_cfg_file")]
+}
+
+# NeXus concept specific mapping tables which require special treatment as the current
+# NOMAD Oasis custom schema implementation delivers them as a list of dictionaries instead
+# of a directly flattenable list of key, value pairs
+
+APM_EXAMPLE_USER_TO_NEXUS = {
+    "prefix_trg": "/ENTRY[entry*]/USER[user*]",
+    "use": [("IDENTIFIER[identifier]/is_persistent", False)],
+    "map_to_str": [("name"), ("affiliation"), ("address"), ("email"), ("telephone_number"), ("role"),
+                   ("social_media_name"), ("social_media_platform"),
+                   ("IDENTIFIER[identifier]/identifier", "orcid"),
+                   ("IDENTIFIER[identifier]/service", "orcid")],
+}
+
+# LEAP6000 can use up to two lasers and voltage pulsing (both at the same time?)
+# ("/ENTRY[entry*]/measurement/instrument/pulser/SOURCE[source*]/name", "load_from", "atom_probe/pulser/source_name"),
+# ("/ENTRY[entry*]/measurement/instrument/pulser/SOURCE[source*]/wavelength", "load_from", "atom_probe/pulser/source_wavelength/value"),
+# ("/ENTRY[entry*]/measurement/instrument/pulser/SOURCE[source*]/wavelength/@units", "load_from", "atom_probe/pulser/source_wavelength/unit"),
+# ("/ENTRY[entry*]/measurement/event_data_apm_set/EVENT_DATA_APM[event_data_apm]/instrument/pulser/SOURCE[source*]/pulse_energy", "load_from", "atom_probe/pulser/source_pulse_energy/value"),
+# ("/ENTRY[entry*]/measurement/event_data_apm_set/EVENT_DATA_APM[event_data_apm]/instrument/pulser/SOURCE[source*]/pulse_energy/@units", "load_from", "atom_probe/pulser/source_pulse_energy/unit"),

--- a/pynxtools_apm/config/apm_oasis_cfg_to_nx_map_2.py
+++ b/pynxtools_apm/config/apm_oasis_cfg_to_nx_map_2.py
@@ -40,19 +40,23 @@
 
 import datetime as dt
 
-from pynxtools_apm.utils.apm_versioning import NX_APM_ADEF_NAME
+from pynxtools_apm.utils.versioning import NX_APM_ADEF_NAME
 
 
 APM_OASIS_TO_NEXUS_CFG = {
     "prefix_trg": "/ENTRY[entry*]",
-    "use": [("definition", f"{NX_APM_ADEF_NAME}"),
-            ("start_time", f"{dt.datetime.now(dt.timezone.utc).isoformat().replace('+00:00', 'Z')}")],
+    "use": [
+        ("definition", f"{NX_APM_ADEF_NAME}"),
+        (
+            "start_time",
+            f"{dt.datetime.now(dt.timezone.utc).isoformat().replace('+00:00', 'Z')}",
+        ),
+    ],
     "map_to_str": [("operation_mode", "operation_mode")],
 }
 
 
 APM_PARAPROBE_EXAMPLE_TO_NEXUS_CFG = {
     "prefix_trg": "/ENTRY[entry*]/CITE[cite*]",
-    "map_to_str": [("doi"),
-                   ("description")],
+    "map_to_str": [("doi"), ("description")],
 }

--- a/pynxtools_apm/config/apm_oasis_cfg_to_nx_map_2.py
+++ b/pynxtools_apm/config/apm_oasis_cfg_to_nx_map_2.py
@@ -1,0 +1,58 @@
+#
+# Copyright The NOMAD Authors.
+#
+# This file is part of NOMAD. See https://nomad-lab.eu for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Dict mapping values for a specifically configured NOMAD Oasis."""
+
+# currently by virtue of design NOMAD Oasis specific examples show how different tools and
+# services can be specifically coupled and implemented so that they work together
+# currently we assume that the ELN provides all those pieces of information to instantiate
+# a NeXus data artifact which technology-partner-specific files or database blobs can not
+# deliver. Effectively a reader uses the eln_data.yaml generic ELN output to fill in these
+# missing pieces of information while typically heavy data (tensors etc) are translated
+# and written from the technology-partner files
+# for large application definitions this can lead to a practical inconvenience:
+# the ELN that has to be exposed to the user is complex and has many fields to fill in
+# just to assure that all information are included in the ELN output and thus consumable
+# by the dataconverter
+# taking the perspective of a specific lab where a specific version of an ELN provided by
+# or running in addition to NOMAD Oasis is used many pieces of information might not change
+# or administrators do not wish to expose this via the end user ELN in an effort to reduce
+# the complexity for end users and make entering of repetitiv information obsolete
+
+# this is the scenario for which deployment_specific mapping shines
+# parsing of deployment specific details in the apm reader is currently implemented
+# such that it executes after reading generic ELN data (eventually available entries)
+# in the template get overwritten
+
+import datetime as dt
+
+from pynxtools_apm.utils.apm_versioning import NX_APM_ADEF_NAME
+
+
+APM_OASIS_TO_NEXUS_CFG = {
+    "prefix_trg": "/ENTRY[entry*]",
+    "use": [("definition", f"{NX_APM_ADEF_NAME}"),
+            ("start_time", f"{dt.datetime.now(dt.timezone.utc).isoformat().replace('+00:00', 'Z')}")],
+    "map_to_str": [("operation_mode", "operation_mode")],
+}
+
+
+APM_PARAPROBE_EXAMPLE_TO_NEXUS_CFG = {
+    "prefix_trg": "/ENTRY[entry*]/CITE[cite*]",
+    "map_to_str": [("doi"),
+                   ("description")],
+}


### PR DESCRIPTION
…ustomizability, and mirror to the state of em so that the same mapping_functors can be used for both apm and em and hence changes no longer have to be made in two places, mapping_functors should be moved to pynxtools but not the current sprint