### PR TITLE
Hard constrain ifes_apt_tc_data_modeling for NOMAD v1.4.1rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "pynxtools>=0.12.0",
-    "ifes_apt_tc_data_modeling>=0.3.2",
+    "ifes_apt_tc_data_modeling==0.3.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
ifes_apt_tc_data_modeling v0.4.0 introduces breaking changes that are currently only meant to be used together with the `merge_cruft` feature branch of pynxtools-apm.